### PR TITLE
Worker no longer gets stuck on missing transactions

### DIFF
--- a/internal/alicenet/alicenet.go
+++ b/internal/alicenet/alicenet.go
@@ -220,6 +220,7 @@ type Transaction struct {
 	Height          int64
 	TransactionHash string
 	ObserveTime     time.Time
+	Missing         *bool
 }
 
 // Key for the Transaction.

--- a/internal/migrations/20220907142719_missing-transactions.down.sql
+++ b/internal/migrations/20220907142719_missing-transactions.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Transactions DROP COLUMN Missing;

--- a/internal/migrations/20220907142719_missing-transactions.up.sql
+++ b/internal/migrations/20220907142719_missing-transactions.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Transactions ADD COLUMN Missing BOOL;


### PR DESCRIPTION
- Purged transactions will be marked as missing
- Will need to be backfilled by another process (#54)
- Closes #39 